### PR TITLE
Add libxss1 dependency

### DIFF
--- a/docker-intellij-ultimate/Dockerfile
+++ b/docker-intellij-ultimate/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 	kmod \
 	less \
 	language-pack-fr \
+	libxss1 \
 	liquidprompt \
   	net-tools \
 	python-mysqldb \


### PR DESCRIPTION
This dependency is required for JCEF browser to work in IJ (previews for Asciidoc & Markdown plugins)